### PR TITLE
fix declaration of package_data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,12 +68,12 @@ setup(
     test_suite='nose.collector',
     version=read_version(),
     package_data={
-        'mercator': ' '.join([
+        'mercator': [
             '*.cfg',
             '*.py',
             '*.rst',
             '*.txt',
-        ]),
+        ],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fixes this:

```python-traceback
Collecting mercator==0.1.9 (from -r requirements.txt (line 68))
  Downloading https://files.pythonhosted.org/packages/44/01/87d42c97794240afa8e9ef61f163e13f193ea944b21289221186878a8f14/mercator-0.1.9.tar.gz
    ERROR: Command errored out with exit status 1:
     command: /opt/lib/local/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-1m648qqc/mercator/setup.py'"'"'; __file__='"'"'/tmp/pip-install-1m648qqc/mercator/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base pip-egg-info
         cwd: /tmp/pip-install-1m648qqc/mercator/
    Complete output (3 lines):
    /usr/local/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'test_require'
      warnings.warn(msg)
    error in mercator setup command: "values of 'package_data' dict" must be a list of strings (got '*.cfg *.py *.rst *.txt')
```


<img width="1231" alt="Screenshot 2019-08-15 at 2 17 27 PM" src="https://user-images.githubusercontent.com/54914/63094046-90008280-bf67-11e9-872e-8a3399409b5d.png">

